### PR TITLE
Switch to LuaRocks 3 as latest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ The `OpenResty <https://openresty.org/en/>`_ fork could be installed with the gi
 Installing LuaRocks
 ^^^^^^^^^^^^^^^^^^^
 
-Available versions: 2.0.8 - 2.0.13, 2.1.0 - 2.1.2, 2.2.0 - 2.2.2, 2.3.0, 2.4.0 - 2.4.4, 3.0.0 - 3.0.4, 3.1.0 - 3.1.3, 3.2.0 - 3.2.1. ``latest`` and ``^`` version aliases point to ``2.4.4``.
+Available versions: 2.0.8 - 2.0.13, 2.1.0 - 2.1.2, 2.2.0 - 2.2.2, 2.3.0, 2.4.0 - 2.4.4, 3.0.0 - 3.0.4, 3.1.0 - 3.1.3, 3.2.0 - 3.2.1. ``latest`` and ``^`` version aliases point to ``3.2.1``.
 
 Version 2.0.8 does not support Lua 5.2. Versions 2.0.8 - 2.1.2 do not support Lua 5.3.
 

--- a/hererocks.py
+++ b/hererocks.py
@@ -1663,8 +1663,8 @@ class LuaRocks(Program):
         "3.0": "3.0.4",
         "3.1": "3.1.3",
         "3.2": "3.2.1",
-        "^": "2.4.4",
-        "latest": "2.4.4"
+        "^": "3.2.1",
+        "latest": "3.2.1"
     }
     checksums = {
         "luarocks-2.0.10.tar.gz"   : "11731dfe6e210a962cb2a857b8b2f14a9ab1043e13af09a1b9455b486401b46e",
@@ -2121,7 +2121,7 @@ def main(argv=None):
         "-r", "--luarocks", help="Version of LuaRocks to install. "
         "Version can be specified in the same way as for standard Lua. "
         "Versions 2.0.8 - 3.2.1 are supported. "
-        "'latest' and '^' are aliases for 2.4.4. "
+        "'latest' and '^' are aliases for 3.2.1. "
         "Default git repo is https://github.com/luarocks/luarocks. "
         "Note that Lua 5.2 is not supported in LuaRocks 2.0.8, "
         "Lua 5.3 is supported only since LuaRocks 2.2.0, and Lua 5.4 is supported only since "


### PR DESCRIPTION
when LuaRocks 3.0.0 was introduced, `latest` became a alias of 3 serie.
but with 3.0.2, `latest` was reverted to 2.4.4.

that happens between releases 0.19.0 and 0.20.0,
so hererocks was never released with LuaRocks 3 as latest.

now, LuaRocks 3.2.x seems mature/stable.

@hishamhm, do you agree ?