### PR TITLE
Fix activate_posix script to work in Bash POSIX Mode

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -94,9 +94,9 @@ activation_script_templates = {
         fi
     """,
     "activate_posix": """
-        s=$(command -V deactivate_lua)
+        s=$(command -V deactivate_lua 2>&1)
         if [ $? -eq 0 ]; then
-            if [ "${s##*function}" = '' ]; then
+            if [ "${s##*function*}" = '' ]; then
                 deactivate_lua
             fi;
         fi;


### PR DESCRIPTION
When Bash is run in POSIX mode (using the `/bin/sh` symlink, the `set -o posix` command, or the `--posix` CLI flag), it is still not 100% compatible with ash/dash.

Here are two differences that affect the `activate_posix` script:

* `command -V` prints errors in stderr instead of stdout
* `command -V function-name` prints the body of the function

Compare:

```
$ sh -c '. $HOME/.luambenvs/lua53/bin/activate_posix; command -V deactivate_lua'          
deactivate_lua is a shell function
                                                                                                                                                                                                                                        
$ bash --posix -c '. $HOME/.luambenvs/lua53/bin/activate_posix; command -V deactivate_lua'
/home/def/.luambenvs/lua53/bin/activate_posix: line 1: command: deactivate_lua: not found
deactivate_lua is a function
deactivate_lua () 
{ 
    if [ -x '/home/def/.luambenvs/lua53/bin/lua' ]; then
        PATH=`'/home/def/.luambenvs/lua53/bin/lua' '/home/def/.luambenvs/lua53/bin/get_deactivated_path.lua'`;
        export PATH;
        hash -r 2> /dev/null;
    fi;
    unset -f deactivate_lua
}
```

Here is a new test and the fix. The test result without the fix:

```
$ nosetests test/cli_test.py:TestCLI.test_activate_posix_script_bash_posix_mode
F
======================================================================
FAIL: test_activate_posix_script_bash_posix_mode (cli_test.TestCLI)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/def/dev/hererocks/test/cli_test.py", line 184, in test_activate_posix_script_bash_posix_mode
    self.check_activate_posix_script(check_cmd)
  File "/home/def/dev/hererocks/test/cli_test.py", line 163, in check_activate_posix_script
    self.assertSuccess(check_cmd, [
  File "/home/def/dev/hererocks/test/cli_test.py", line 52, in assertSuccess
    raise AssertionError("Expected to see '{}' in output of command '{}', got output:\n{}".format(
AssertionError: Expected to see 'b'reactivate 1: /home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin'' in output of command 'bash --posix test/check_activate_posix.sh', got output:
b'initial: /home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\ntest/here/bad (dir) 1/bin/activate_posix: line 1: command: deactivate_lua: not found\nactivate 1: /home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\ndeactivate 1: /home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\ntest/here/bad (dir) 1/bin/activate_posix: line 1: command: deactivate_lua: not found\nactivate 1 again: /home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\nreactivate 1: /home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\nactivate 2: /home/def/dev/hererocks/test/here/bad (dir) 2/bin:/home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\ndeactivate 2: /home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/dev/hererocks/test/here/bad (dir) 1/bin:/home/def/.virtualenvs/hererocks/bin:/home/def/.local/bin:/home/def/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin\n'
```