### PR TITLE
Fix and improve CI tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = hererocks

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,24 @@
 language: python
 
-matrix:
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+
+jobs:
   include:
-    - os: linux
-      python: 2.7
-    - os: linux
-      python: 3.5
     - os: osx
       language: generic
+      env: MACOSX_DEPLOYMENT_TARGET=10.12
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sudo pip2 install pyflakes pycodestyle coverage coveralls nose --ignore-installed; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip install pyflakes pycodestyle coverage coveralls nose; fi
+  - pip install flake8 pytest-cov coveralls
 
 script:
-  - pyflakes .
-  - pycodestyle .
-  - nosetests
+  - flake8
+  - pytest --cov
+
+after_success:
   - coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,16 +2,19 @@ version: 1.0.{build}
 
 environment:
   matrix:
+  - Python: 27-x64
   - Python: 35-x64
-  - Python: 27
+  - Python: 36-x64
+  - Python: 37-x64
+  - Python: 38-x64
 
 build_script:
   - PATH %CD%\here\bin;C:\mingw\bin;C:\python%Python%;C:\python%Python%\scripts;%PATH%
-  - pip install pyflakes pycodestyle coverage coveralls nose
+  - pip install flake8 pytest-cov coveralls
 
 test_script:
-  - pyflakes .
-  - pycodestyle .
-  - nosetests
-  - coverage report
+  - flake8
+  - pytest --cov
+
+on_success:
   - if not "%COVERALLS_REPO_TOKEN%"=="" coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
-[pycodestyle]
+[flake8]
 ignore = E203,E302,E305,E501

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -12,10 +12,6 @@ skip_if_win = unittest.skipIf(sys.platform.startswith("win"), "requires POSIX")
 
 
 class TestCLI(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        subprocess.check_call(["coverage", "erase"])
-
     def setUp(self):
         if os.name == "nt":
             # On Windows tests randomly fail here with errors such as 'can not remove here\bin: directory not empty'.
@@ -54,7 +50,7 @@ class TestCLI(unittest.TestCase):
 
     def assertHererocksSuccess(self, args, expected_output_lines=None, location="here"):
         self.assertSuccess([
-            "coverage", "run", "-a",
+            sys.executable,
             "hererocks.py", os.path.join("test", location)] + args, expected_output_lines, from_prefix=False)
 
     def test_install_latest_lua_with_latest_luarocks(self):


### PR DESCRIPTION
* **Run tests on Travis CI**
  They haven't been run due to improperly configured nose (see https://travis-ci.org/github/luarocks/hererocks/jobs/706997418#L233)
* **Fix tests on macOS** (see https://travis-ci.org/github/un-def/hererocks/jobs/706841264#L284)
* **Replace nose with pytest**
  pytest is de facto standard test framework and runner
* **Remove coverage calls from tests**
  pytest-cov can measure coverage of subprocess'ed scripts
* **Replace pyflakes and pycodestyle with flake8**
  flake8 is basically 3-in-1 tool (+ mccabe)
* **Add coverage config**
* **linux and win: test against all supported python versions: 2.7, 3.5, 3.6, 3.7, 3.8**

