### PR TITLE
Use HTTPS when downloading Lua & LuaRocks

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -899,8 +899,8 @@ class Patch(object):
 class RioLua(Lua):
     name = "lua"
     title = "Lua"
-    base_download_urls = ["http://www.lua.org/ftp", "http://webserver2.tecgraf.puc-rio.br/lua/mirror/ftp"]
-    work_base_download_url = "http://www.lua.org/work"
+    base_download_urls = ["https://www.lua.org/ftp", "https://webserver2.tecgraf.puc-rio.br/lua/mirror/ftp"]
+    work_base_download_url = "https://www.lua.org/work"
     default_repo = "https://github.com/lua/lua"
     versions = [
         "5.1", "5.1.1", "5.1.2", "5.1.3", "5.1.4", "5.1.5",
@@ -1966,7 +1966,7 @@ class RaptorJIT(LuaJIT):
 class LuaRocks(Program):
     name = "luarocks"
     title = "LuaRocks"
-    base_download_url = "http://luarocks.github.io/luarocks/releases"
+    base_download_url = "https://luarocks.github.io/luarocks/releases"
     default_repo = "https://github.com/luarocks/luarocks"
     versions = [
         "2.0.8", "2.0.9", "2.0.10", "2.0.11", "2.0.12", "2.0.13",


### PR DESCRIPTION
I'm having trouble using hererocks when building a docker image. I believe this is related to HTTP being used and that somehow messing up the routing.

The Dockefile:
```Dockerfile
FROM centos:7

# Dependencies to hererocks.
RUN yum install -y \
    gcc-4.8.5 \
    unzip-6.0 \
    make-3.82 \
    python3-3.6.8 \
    && yum -y clean all

RUN pip3 --no-cache-dir install \
    hererocks==0.23.0

RUN hererocks --no-readline --lua 5.3.6 --luarocks 3.5.0 /opt/lua
```

The URL changes I've done here resolves my issue. Is there a reason for keeping any of the HTTP URLs?