### PR TITLE
Visual Studio 2019 patch

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -2343,7 +2343,7 @@ def setup_vs_and_rerun(vs_version, arch):
 
 def setup_vs_by_vswhere(target):
     '''
-    vswhere: https://github.com/Microsoft/vswhere   
+    vswhere: https://github.com/Microsoft/vswhere
     detect Visual Studio 2017 versin 15.2 or later
     '''
     if target != "vs":

--- a/hererocks.py
+++ b/hererocks.py
@@ -2363,9 +2363,9 @@ def setup_vs_by_vswhere(target):
     if not os.path.exists(vcvars):
         return
 
-    for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
+    for line in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
         try:
-            k, v = l.split('=', maxsplit=1)
+            k, v = line.split('=', maxsplit=1)
             k = k.upper()
             if k == 'PATH':
                 path = os.environ['PATH']

--- a/hererocks.py
+++ b/hererocks.py
@@ -2347,8 +2347,8 @@ def setup_vs(target):
         'ProgramFiles(x86)'] + '\\Microsoft Visual Studio\\Installer\\vswhere.exe'
     if os.path.exists(vswhere):
         install_dir = run(vswhere, '-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '-property', 'installationPath', get_output=True)
-        if os.path.exists(install_dir):
-            vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
+        vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
+        if os.path.exists(vcvars):
             for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
                 try:
                     k, v = l.split('=', maxsplit=1)

--- a/hererocks.py
+++ b/hererocks.py
@@ -2342,6 +2342,26 @@ def setup_vs_and_rerun(vs_version, arch):
     sys.exit(exit_code)
 
 def setup_vs(target):
+    # setup environment variables for latest vc
+    vswhere = os.environ[
+        'ProgramFiles(x86)'] + '\\Microsoft Visual Studio\\Installer\\vswhere.exe'
+    if os.path.exists(vswhere):
+        install_dir = run(vswhere, '-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '-property', 'installationPath', get_output=True)
+        if os.path.exists(install_dir):
+            vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
+            for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
+                if l.startswith('PATH='):
+                    for p in l[len('PATH='):].split(';'):
+                        if p not in os.environ['PATH']:
+                            os.environ['PATH'] = p + ';' + os.environ['PATH']
+                    print('PATH=', os.environ['PATH'])
+                elif l.startswith('INCLUDE='):
+                    os.environ['INCLUDE'] = l[len('INCLUDE='):]
+                    print('INCLUDE=', os.environ['INCLUDE'])
+                elif l.startswith('LIB='):
+                    os.environ['LIB'] = l[len('LIB='):]
+                    print('LIB=', os.environ['LIB'])
+
     # If using vsXX_YY or vs_XX target, set VS up by writing a .bat file calling corresponding vcvarsall.bat
     # before recursively calling hererocks, passing arguments through a temporary file using
     # --actual-argv-file because passing special characters like '^' as an argument to a batch file is not fun.

--- a/hererocks.py
+++ b/hererocks.py
@@ -2341,30 +2341,50 @@ def setup_vs_and_rerun(vs_version, arch):
     remove_dir(temp_dir)
     sys.exit(exit_code)
 
-def setup_vs(target):
-    # setup environment variables for latest vc
+def setup_vs_by_vswhere(target):
+    '''
+    vswhere: https://github.com/Microsoft/vswhere   
+    detect Visual Studio 2017 versin 15.2 or later
+    '''
+    if target != "vs":
+        return
+
+    if program_exists("cl"):
+        # already setup
+        return
+
     vswhere = os.environ[
         'ProgramFiles(x86)'] + '\\Microsoft Visual Studio\\Installer\\vswhere.exe'
-    if os.path.exists(vswhere):
-        install_dir = run(vswhere, '-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '-property', 'installationPath', get_output=True)
-        vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
-        if os.path.exists(vcvars):
-            for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
-                try:
-                    k, v = l.split('=', maxsplit=1)
-                    k = k.upper()
-                    if k == 'PATH':
-                        path = os.environ['PATH']
-                        for p in v.split(';'):
-                            if p not in path:
-                                path = p + ';' + path
-                        os.environ['PATH'] = path
-                    elif k == 'INCLUDE':
-                        os.environ['INCLUDE'] = v
-                    elif k == 'LIB':
-                        os.environ['LIB'] = v
-                except ValueError:
-                    pass
+    if not os.path.exists(vswhere):
+        return
+
+    install_dir = run(vswhere, '-latest', '-products', '*', '-requires', 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64', '-property', 'installationPath', get_output=True)
+    vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
+    if not os.path.exists(vcvars):
+        return
+
+    for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
+        try:
+            k, v = l.split('=', maxsplit=1)
+            k = k.upper()
+            if k == 'PATH':
+                path = os.environ['PATH']
+                for p in v.split(';'):
+                    if p not in path:
+                        path = p + ';' + path
+                os.environ['PATH'] = path
+            elif k == 'INCLUDE':
+                os.environ['INCLUDE'] = v
+            elif k == 'LIB':
+                os.environ['LIB'] = v
+        except ValueError:
+            pass
+
+def setup_vs(target):
+    try:
+        setup_vs_by_vswhere(target)
+    except Exception:
+        pass
 
     # If using vsXX_YY or vs_XX target, set VS up by writing a .bat file calling corresponding vcvarsall.bat
     # before recursively calling hererocks, passing arguments through a temporary file using

--- a/hererocks.py
+++ b/hererocks.py
@@ -2350,17 +2350,21 @@ def setup_vs(target):
         if os.path.exists(install_dir):
             vcvars = install_dir + '\\VC\\Auxiliary\\Build\\vcvars64.bat'
             for l in run(os.environ['COMSPEC'], '/C', vcvars, '&', 'set', get_output=True).splitlines():
-                if l.startswith('PATH='):
-                    for p in l[len('PATH='):].split(';'):
-                        if p not in os.environ['PATH']:
-                            os.environ['PATH'] = p + ';' + os.environ['PATH']
-                    print('PATH=', os.environ['PATH'])
-                elif l.startswith('INCLUDE='):
-                    os.environ['INCLUDE'] = l[len('INCLUDE='):]
-                    print('INCLUDE=', os.environ['INCLUDE'])
-                elif l.startswith('LIB='):
-                    os.environ['LIB'] = l[len('LIB='):]
-                    print('LIB=', os.environ['LIB'])
+                try:
+                    k, v = l.split('=', maxsplit=1)
+                    k = k.upper()
+                    if k == 'PATH':
+                        path = os.environ['PATH']
+                        for p in v.split(';'):
+                            if p not in path:
+                                path = p + ';' + path
+                        os.environ['PATH'] = path
+                    elif k == 'INCLUDE':
+                        os.environ['INCLUDE'] = v
+                    elif k == 'LIB':
+                        os.environ['LIB'] = v
+                except ValueError:
+                    pass
 
     # If using vsXX_YY or vs_XX target, set VS up by writing a .bat file calling corresponding vcvarsall.bat
     # before recursively calling hererocks, passing arguments through a temporary file using


### PR DESCRIPTION
This fix detects the installation of vc by [vswhere](https://github.com/Microsoft/vswhere) and adds the environment variables `INCLUDE`, `LIB`, `PATH` from the run of `vcvars64.bat`.

I'm using `VisualStudio2019BuildTools` on Windows10(64bit)

Thank you !