### PR TITLE
Add the most recent `Programming Language :: Python` classifiers to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,10 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8"
+        "Programming Language :: Python :: 3.9"
+        "Programming Language :: Python :: 3.10"
+        "Programming Language :: Python :: 3.11"
     ],
     py_modules=["hererocks"],
     entry_points={


### PR DESCRIPTION
I needed to install `hererocks` package from AUR (Archlinux User Repositories). But it fails because of the classifiers. So i changed `setup.py`. Got the classifiers from here: https://pypi.org/pypi?%3Aaction=list_classifiers. Cheers and thx for the cool Repo!