### PR TITLE
Adopt LuaJIT rolling release changes

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -2055,17 +2055,19 @@ class LuaJIT(Lua):
 
                 run("msvcbuild.bat")
         else:
+            make_args = []
             if opts.target == "mingw" and program_exists("mingw32-make"):
                 make = "mingw32-make"
+                make_args.append("SHELL=cmd")
             elif opts.target == "freebsd":
                 make = "gmake"
             else:
                 make = "make"
 
-            if not cflags:
-                run(make)
-            else:
-                run(make, "XCFLAGS=" + " ".join(cflags))
+            if cflags:
+                make_args.append("XCFLAGS=" + " ".join(cflags))
+
+            run(make, make_args)
 
     def make_install(self):
         luajit_file = exe("luajit")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -73,15 +73,14 @@ class TestCLI(unittest.TestCase):
         self.assertHererocksSuccess(["--show"], ["Programs installed in", "cloned from https://github.com/lua/lua"])
         self.assertSuccess(["luarocks", "--version"])
 
-    @unittest.expectedFailure
     def test_verbose_install_bleeding_edge_luajit_with_latest_luarocks(self):
         self.assertHererocksSuccess(["--luajit", "@v2.1", "--luarocks", "latest", "--verbose"])
-        self.assertSuccess(["lua", "-v"], ["LuaJIT 2.1.0"])
+        self.assertSuccess(["lua", "-v"], ["LuaJIT 2.1"])
         self.assertSuccess(["lua", "-e", "require 'jit.bcsave'"])
 
         self.assertSuccess(["luarocks", "--version"])
         self.assertSuccess(["luarocks", "make", os.path.join("test", "hererocks-test-scm-1.rockspec")])
-        self.assertSuccess(["hererocks-test"], ["LuaJIT 2.1.0"])
+        self.assertSuccess(["hererocks-test"], ["LuaJIT 2.1"])
 
         self.assertHererocksSuccess(["--luajit", "@v2.1", "--luarocks", "latest"], ["already installed"])
         self.assertHererocksSuccess(["--show"], ["cloned from https://github.com/LuaJIT/LuaJIT"])


### PR DESCRIPTION
LuaJIT recently switched to the rolling release scheme:

* 2.0.x -> 2.0.ROLLING
* 2.1.x -> 2.1.ROLLING

See LuaJIT commits:

* https://github.com/LuaJIT/LuaJIT/commit/50e0fa03c48cb9af03c3efdc3100f12687651a2e
* https://github.com/LuaJIT/LuaJIT/commit/2090842410e0ba6f81fad310a77bf5432488249a

Fixes: https://github.com/luarocks/hererocks/issues/25

---

In addition to the changing of the versioning scheme, there has been introduced some changes in the MinGW build.

See the commit and the PR:

* https://github.com/LuaJIT/LuaJIT/commit/19707009bfb8d1fe59a5c328034e8e8ad1b56232
* https://github.com/LuaJIT/LuaJIT/pull/1071

The problem is that if `sh` is in `PATH`, mingw32-make will use `sh` instead of `cmd.exe`, but some recipes in Makefile use `cmd.exe` syntax if MinGW is detected. I have no solid proof of it, only [this post on Stack Overflow](https://stackoverflow.com/questions/24066265/force-mingw32-make-to-ignore-sh), but I did a simple experiment:

1. I have a machine with Windows and `sh.exe`/`bash.exe` provided by Git for Windows.
2. I've tried to install LuaJIT@v2.1 from the official repository (not using hererocks, only official instructions) with no success:

    ```
    D:\LuaJIT\src>mingw32-make
    VERSION   luajit.h
    /usr/bin/bash: -c: line 1: syntax error near unexpected token `('
    /usr/bin/bash: -c: line 1: `if exist ..\.git ( git show -s --format=%%ct >luajit_relver.txt ) else ( type ..\.relver >luajit_relver.txt )'
    mingw32-make: *** [Makefile:658: luajit.h] Error 2
    ```

    As you can see, bash tries to execute Windows batch script and fails (`syntax error near unexpected token`)

    The same with `clean` recipe:

    ```
    D:\LuaJIT\src>mingw32-make clean
    del luajit.exe libluajit.a lua51.dll host\minilua.exe host\buildvm.exe lj_vm.S lj_bcdef.h lj_ffdef.h lj_libdef.h lj_recdef.h lj_folddef.h host\buildvm_arch.h luajit.h luajit_relver.txt jit\vmdef.lua *.o host\*.o *.obj *.lib *.exp *.dll *.exe *.manifest *.pdb *.ilk
    /usr/bin/bash: line 1: del: command not found
    mingw32-make: *** [Makefile:626: clean] Error 127
    ````

    Yep, `del` instead of `rm`.

3. But when I either removed `sh.exe` from `PATH` or run mingw32-make with `SHELL=cmd`, all problem disappeared.

With this patch, we force mingw32-make to use Windows shell (`SHELL=cmd`).

