### PR TITLE
CI: Update test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,29 +14,85 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version:
-          - '2.7'
-          - '3.6'
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
-          - '3.11'
-          - '3.12'
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          # macOS (12, 13 ­­-- Intel, 14 -- ARM)
+          - os: macos-12
+            python-version: '2.7'
+          - os: macos-12
+            python-version: '3.8'
+            setup-python: true
+          - os: macos-12
+            python-version: '3.9'
+            setup-python: true
+          - os: macos-13
+            python-version: '3.10'
+            setup-python: true
+          - os: macos-13
+            python-version: '3.11'
+            setup-python: true
+          - os: macos-14
+            python-version: '3.12'
+          # Windows
+          - os: windows-2019
+            python-version: '3.7'
+          - os: windows-2019
+            python-version: '3.8'
+            setup-python: true
+          - os: windows-2022
+            python-version: '3.9'
+          - os: windows-2022
+            python-version: '3.10'
+            setup-python: true
+          - os: windows-2022
+            python-version: '3.11'
+            setup-python: true
+          - os: windows-2022
+            python-version: '3.12'
+            setup-python: true
+          # Ubuntu
+          - os: ubuntu-20.04
+            python-version: '3.6'
+            setup-python: true
+          - os: ubuntu-20.04
+            python-version: '3.7'
+            setup-python: true
+          - os: ubuntu-20.04
+            python-version: '3.8'
+          - os: ubuntu-20.04
+            python-version: '3.9'
+            setup-python: true
+          - os: ubuntu-22.04
+            python-version: '3.10'
+          - os: ubuntu-22.04
+            python-version: '3.11'
+            setup-python: true
+          - os: ubuntu-24.04
+            python-version: '3.12'
     steps:
-      - uses: actions/checkout@v3
-      - uses: MatteoH2O1999/setup-python@v3
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        if: ${{ matrix.setup-python }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-build: info
-          cache-build: true
-      - name: Install test runner
+      - name: Configure PATH to use preinstalled Python 2.7
+        if: ${{ startsWith(matrix.os, 'macos') && matrix.python-version == '2.7' }}
         run: |
-          pip install --upgrade pip wheel setuptools
+          echo '/Library/Frameworks/Python.framework/Versions/2.7/bin' >> $GITHUB_PATH
+      - name: Assert Python version
+        run: |
+          python -c 'import sys
+          assert "%d.%d" % sys.version_info[:2] == "${{ matrix.python-version }}", sys.version'
+      - name: Install readline
+        if: ${{ matrix.os == 'ubuntu-24.04' }}
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get install -y libreadline-dev
+      - name: Install test runner
+        env:
+          PIP_BREAK_SYSTEM_PACKAGES: true
+        run: |
           pip install pytest-cov
       - name: Run tests
         run: |

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -141,6 +142,7 @@ class TestCLI(unittest.TestCase):
             self.assertHererocksSuccess(["--lua", "5.3.2", "--patch", "--target", "vs"])
             self.assertSuccess(["lua", "-e", "assert(coroutine.wrap(string.gmatch('x', '.'))() == 'x')"])
 
+    @unittest.skipIf(sys.platform == "darwin" and platform.processor() == "arm", "ARM Macs are not supported")
     def test_install_luajit_with_compat_with_apicheck(self):
         self.assertHererocksSuccess(["--luajit", "latest", "--compat", "5.2", "--cflags=-DLUA_USE_APICHECK"])
 


### PR DESCRIPTION
* Use preinstalled Python when possible
* Test Python 2.7 on macOS only (it's preinstalled, no need to compile as with other OSes)
* Drop Python 3.6, 3.7 on some OSes
* Use era appropriate OS/Python version pairs
* Skip LuaJIT 2.0.5 test on ARM Macs (not supported)