### PR TITLE
WIP: CI: Update Codecov Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,4 +98,6 @@ jobs:
         run: |
           pytest --cov -- test
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
https://github.com/codecov/codecov-action/releases/tag/v4.0.0

`v4` no longer supports tokenless uploading, but this feature is all but broken due to rate limits, the last successful upload was three month ago: https://app.codecov.io/gh/luarocks/hererocks/commit/4ea0822c30c4ed568d6cb43038224b93aae436f4

For example, https://github.com/luarocks/hererocks/actions/runs/9379552301/job/25824719887

> [2024-06-05T06:57:06.318Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 429 - {'detail': ErrorDetail(string='Rate limit reached. Please upload with the Codecov repository upload token to resolve issue. Expected time to availability: 876s.', code='throttled')}

Alfo fixes the following warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: codecov/codecov-action@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
