### PR TITLE
Support XDG cache directory

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -242,12 +242,13 @@ def get_default_cache():
 
         return os.path.join(cache_root, "HereRocks", "Cache")
     else:
-        home = os.path.expanduser("~")
+        cache_root = os.getenv("XDG_CACHE_HOME", "~/.cache")
+        expanded_cache_root = os.path.expanduser(cache_root)
 
-        if home == "~":
+        if expanded_cache_root.startswith("~"):
             return None
-        else:
-            return os.path.join(home, ".cache", "hererocks")
+
+        return os.path.join(expanded_cache_root, "hererocks")
 
 def download(url, filename):
     response = urlopen(url, timeout=opts.timeout)


### PR DESCRIPTION
The XDG base directory specification specifies user directories for
common application files, like config, cache and data files. Users can
set the location of these directories using environment variables like
`$XDG_CACHE_HOME`.

This commit adds support for this specification by checking if
XDG_CACHE_HOME is set. If so, it is used as cache dir. Otherwise, the
previous default of ~/.cache will be used.
