### PR TITLE
CI: Update test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,13 +15,8 @@ jobs:
     strategy:
       matrix:
         include:
-          # macOS (12, 13 ­­-- Intel, 14 -- ARM)
-          - os: macos-12
-            python-version: '2.7'
-          - os: macos-12
-            python-version: '3.8'
-            setup-python: true
-          - os: macos-12
+          # macOS (13 ­­-- Intel, 14 -- ARM)
+          - os: macos-13
             python-version: '3.9'
             setup-python: true
           - os: macos-13
@@ -30,17 +25,12 @@ jobs:
           - os: macos-13
             python-version: '3.11'
             setup-python: true
-          - os: macos-13
+          - os: macos-14
             python-version: '3.12'
             setup-python: true
           - os: macos-14
             python-version: '3.13'
           # Windows
-          - os: windows-2019
-            python-version: '3.7'
-          - os: windows-2019
-            python-version: '3.8'
-            setup-python: true
           - os: windows-2022
             python-version: '3.9'
           - os: windows-2022
@@ -56,15 +46,7 @@ jobs:
             python-version: '3.13'
             setup-python: true
           # Ubuntu
-          - os: ubuntu-20.04
-            python-version: '3.6'
-            setup-python: true
-          - os: ubuntu-20.04
-            python-version: '3.7'
-            setup-python: true
-          - os: ubuntu-20.04
-            python-version: '3.8'
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: '3.9'
             setup-python: true
           - os: ubuntu-22.04


### PR DESCRIPTION
- Drop deprecated images:
  - macos-12
  - windows-2019
  - ubuntu-20.04
- Drop Python versions prior 3.9