### PR TITLE
Drop support for legacy Python 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ hererocks
 
 |gh-workflow| |codecov|
 
-``hererocks`` is a single file Python 2.7/3.x script for installing `Lua <http://http://www.lua.org/>`_
+``hererocks`` is a single file Python script for installing `Lua <http://http://www.lua.org/>`_
 (or `LuaJIT <http://luajit.org/>`_ or `moonjit <https://github.com/moonjit/moonjit>`_ or `RaptorJIT <https://github.com/raptorjit/raptorjit>`_)
 and `LuaRocks <https://luarocks.org/>`_, its package manager, into a local directory.
 It configures Lua to only see packages installed by that bundled version of LuaRocks, so that the installation is isolated.
@@ -41,7 +41,7 @@ Manually: download hererocks with ``wget https://raw.githubusercontent.com/luaro
 Requirements
 ------------
 
-* Python 2.7 or 3.x
+* A currently supported version of Python.
 * Git for installing from Git repositories.
 * Compiler:
 

--- a/hererocks.py
+++ b/hererocks.py
@@ -2,8 +2,6 @@
 
 """A tool for installing Lua and LuaRocks locally."""
 
-from __future__ import print_function
-
 import argparse
 import contextlib
 import hashlib
@@ -22,13 +20,9 @@ import tarfile
 import tempfile
 import textwrap
 import zipfile
+from urllib.error import URLError
+from urllib.request import urlopen
 
-
-try:
-    from urllib2 import URLError, urlopen
-except ImportError:
-    from urllib.error import URLError
-    from urllib.request import urlopen
 
 if os.name == "nt":
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ maintainers = [
 keywords = ["lua"]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Python 2 died 2,412 days ago on 1/1/2020.