### PR TITLE
Drop support for archived moonjit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ hererocks
 |gh-workflow| |codecov|
 
 ``hererocks`` is a single file Python 2.7/3.x script for installing `Lua <http://http://www.lua.org/>`_
-(or `LuaJIT <http://luajit.org/>`_ or `moonjit <https://github.com/moonjit/moonjit>`_ or `RaptorJIT <https://github.com/raptorjit/raptorjit>`_)
+(or `LuaJIT <http://luajit.org/>`_ or `RaptorJIT <https://github.com/raptorjit/raptorjit>`_)
 and `LuaRocks <https://luarocks.org/>`_, its package manager, into a local directory.
 It configures Lua to only see packages installed by that bundled version of LuaRocks, so that the installation is isolated.
 
@@ -86,7 +86,7 @@ After installation Lua and LuaRocks binaries will be in the ``bin`` subdirectory
 Version selection
 ^^^^^^^^^^^^^^^^^
 
-``--lua/-l``, ``--luajit/-j``, ``--moonjit/-m``, ``--raptorjit`` and ``--luarocks/-r`` options select versions of programs to install.
+``--lua/-l``, ``--luajit/-j``, ``--raptorjit`` and ``--luarocks/-r`` options select versions of programs to install.
 There are three ways to specify how to fetch the sources:
 
 * Using version number, such as ``5.1.5``. If patch or minor versions are left out the latest possible version will be used, e.g. for Lua ``5.2`` is currently equivalent to ``5.2.4`` and for LuaJIT ``2.1`` is same as ``2.1.0-beta3``. ``latest`` or ``^`` can be used to select the latest stable version. ``hererocks`` will fetch and unpack sources of the selected version from corresponding downloads location, verifying their SHA256 checksum.
@@ -113,11 +113,6 @@ Installing LuaJIT
 Available versions: 2.0.0 - 2.0.5, 2.1.0-beta1 - 2.1.0-beta3. ``latest`` and ``^`` version aliases point to ``2.0.5``.
 
 The `OpenResty <https://openresty.org/en/>`_ fork could be installed with the git URI option: ``--luajit https://github.com/openresty/luajit2.git@v2.1-agentzh``.
-
-Installing moonjit
-^^^^^^^^^^^^^^^^^^
-
-Available versions: 2.1.1 - 2.2.0. ``latest`` and ``^`` version aliases point to ``2.1.2``.
 
 Installing RaptorJIT
 ^^^^^^^^^^^^^^^^^^^^

--- a/hererocks.py
+++ b/hererocks.py
@@ -2514,33 +2514,6 @@ class LuaJIT(BaseJIT):
     def get_download_urls(self):
         return ["{}/v{}.tar.gz".format(self.base_download_url, self.version)]
 
-class MoonJIT(BaseJIT):
-    name = "moonjit"
-    title = "moonjit"
-    base_download_url = "https://github.com/moonjit/moonjit/archive"
-    default_repo = "https://github.com/moonjit/moonjit"
-    versions = [
-        "2.1.1", "2.1.2",
-        "2.2.0"
-    ]
-    translations = {
-        "2.1": "2.1.2",
-        "2.2": "2.2.0",
-        "^": "2.1.2",
-        "latest": "2.1.2"
-    }
-    checksums = {
-        "moonjit-2.1.1.tar.gz": "aa04d47f23bf24173e58dff0a727e8061fb88c07966a956bd86b13dae5542616",
-        "moonjit-2.1.2.tar.gz": "c3de8e29aa617fc594c043f57636ab9ad71af2b4a3a513932b05f5cdaa4320b2",
-        "moonjit-2.2.0.tar.gz": "83deb2c880488dfe7dd8ebf09e3b1e7613ef4b8420de53de6f712f01aabca2b6",
-    }
-
-    def get_download_name(self):
-        return "{}-{}.tar.gz".format(self.name, self.version)
-
-    def get_download_urls(self):
-        return ["{}/{}.tar.gz".format(self.base_download_url, self.version)]
-
 class RaptorJIT(BaseJIT):
     name = "raptorjit"
     title = "RaptorJIT"
@@ -2794,8 +2767,7 @@ class LuaRocks(Program):
     def build(self):
         self.lua_identifiers = self.all_identifiers.get("lua",
                                                         self.all_identifiers.get("LuaJIT",
-                                                                                 self.all_identifiers.get("moonjit",
-                                                                                                          self.all_identifiers.get("raptorjit"))))
+                                                                                 self.all_identifiers.get("raptorjit")))
 
         if self.lua_identifiers is None:
             sys.exit("Error: can't install LuaRocks: Lua is not present in {}".format(opts.location))
@@ -3130,15 +3102,6 @@ def install_programs(vs_already_set_up):
 
         os.chdir(start_dir)
 
-    if opts.moonjit:
-        if "lua" in identifiers:
-            del identifiers["lua"]
-
-        if MoonJIT(opts.moonjit).update_identifiers(identifiers):
-            save_installed_identifiers(identifiers)
-
-        os.chdir(start_dir)
-
     if opts.raptorjit:
         if "lua" in identifiers:
             del identifiers["lua"]
@@ -3200,12 +3163,6 @@ def main(argv=None):
         "Versions 2.0.0 - 2.1.0-beta3 are supported. "
         "'latest' and '^' are aliases for to 2.0.5. "
         "Default git repo is https://github.com/luajit/luajit. ")
-    parser.add_argument(
-        "-m", "--moonjit", help="Version of moonjit to install. "
-        "Version can be specified in the same way as for standard Lua. "
-        "Versions 2.1.1 - 2.2.0 are supported. "
-        "'latest' and '^' are aliases for to 2.1.2. "
-        "Default git repo is https://github.com/moonjit/moonjit. ")
     parser.add_argument(
         "--raptorjit", help="Version of RaptorJIT to install. "
         "Version can be specified in the same way as for standard Lua. "
@@ -3289,13 +3246,11 @@ def main(argv=None):
         nb_lua += 1
     if opts.luajit:
         nb_lua += 1
-    if opts.moonjit:
-        nb_lua += 1
     if opts.raptorjit:
         nb_lua += 1
 
     if nb_lua == 0 and not opts.luarocks and not opts.show:
-        parser.error("a version of Lua, LuaJIT, moonjit, RaptorJIT or LuaRocks needs to be specified unless --show is used")
+        parser.error("a version of Lua, LuaJIT, RaptorJIT or LuaRocks needs to be specified unless --show is used")
 
     if nb_lua > 1:
         parser.error("can't install more than one Lua interpreter")


### PR DESCRIPTION
The __moonjet__ codebase was archived and its last commit was 6 years ago to let's drop support for it.
* https://github.com/moonjit/moonjit